### PR TITLE
make version file zeitwerk compatible

### DIFF
--- a/config/initializers/zeitwerk.rb
+++ b/config/initializers/zeitwerk.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# this CANVAS_ZEITWERK constant flag is defined in canvas' "application.rb"
+# from an env var. It should be temporary,
+# and removed once we've fully upgraded to zeitwerk autoloading.
+if defined?(CANVAS_ZEITWERK) && CANVAS_ZEITWERK
+
+  # make sure we don't try to create a "CanvasConnect::Version" thing,
+  # because that doesn't exist
+  Rails.autoloaders.main.ignore("#{__dir__}/../../lib/canvas_connect/version.rb")
+
+end

--- a/lib/canvas_connect/version.rb
+++ b/lib/canvas_connect/version.rb
@@ -1,3 +1,3 @@
 module CanvasConnect
-  VERSION = '0.3.12'
+  VERSION = '0.3.13'
 end


### PR DESCRIPTION
This makes it so that canvas can use this as an engine error-free when the zeitwerk autoloader is enabled.