### PR TITLE
explicitly require version for adobe connect plugin

### DIFF
--- a/lib/canvas/plugins/adobe_connect.rb
+++ b/lib/canvas/plugins/adobe_connect.rb
@@ -16,6 +16,8 @@
 # with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+require 'canvas_connect/version'
+
 module Canvas
   module Plugins
     class AdobeConnect

--- a/lib/canvas_connect/version.rb
+++ b/lib/canvas_connect/version.rb
@@ -1,3 +1,3 @@
 module CanvasConnect
-  VERSION = '0.3.13'
+  VERSION = '0.3.14'
 end


### PR DESCRIPTION
refs FOO-2433
flag=none

Makes sure we can eagerload all files through
zeitwerk correctly

TEST PLAN:
  1) specs pass